### PR TITLE
Use dictionary for parse_image to speed up image parsing.

### DIFF
--- a/src/gifmaze/gifmaze/encoder.py
+++ b/src/gifmaze/gifmaze/encoder.py
@@ -24,6 +24,7 @@ Reference for the GIF89a specification:
 
 """
 from struct import pack
+from collections import OrderedDict
 
 
 __all__ = ['screen_descriptor', 'loop_control_block', 'graphics_control_block',
@@ -89,18 +90,17 @@ def parse_image(img):
     `img` must be an instance of `PIL.Image.Image` class and has .gif format.
     """
     data = list(img.getdata())
-    colors = []
+    colors = OrderedDict()
     indices = []
     count = 0
 
     for c in data:
         if c not in colors:
-            colors.append(c)
+            colors[c] = count
             indices.append(count)
             count += 1
         else:
-            i = colors.index(c)
-            indices.append(i)
+            indices.append(colors[c])
 
     palette = []
     for c in colors:


### PR DESCRIPTION
In parse_image, we do a membership check on colors, which is a list, and takes O(n) time. Using a dictionary is effectively a drop in replacement, but reduces lookup time to O(1), and offers a 5x speedup for the image for example4() in gifmaze/example_maze_animations (1.1421077s to 0.213111s)

(Note that in Python 3.6+, dictionaries are ordered by default, but if you want to support 3.5 and below, OrderedDict is need)