### PR TITLE
Make fractal3d.py Python 3.8 ready

### DIFF
--- a/src/fractal3d/fractal3d.py
+++ b/src/fractal3d/fractal3d.py
@@ -84,7 +84,7 @@ class Fractal3D(pyglet.window.Window):
             visible=False,
             vsync=False,
         )
-        self._start_time = time.clock()
+        self._start_time = time.process_time()
         self.AA = AA
         self.shader = Shader(["./glsl/fractal3d.vert"], [scene_file])
         self.scene = pathlib.Path(scene_file).resolve().stem
@@ -105,7 +105,7 @@ class Fractal3D(pyglet.window.Window):
         self.clear()
         gl.glViewport(0, 0, self.width, self.height)
         with self.shader:
-            self.shader.uniformf("iTime", time.clock() - self._start_time)
+            self.shader.uniformf("iTime", time.process_time() - self._start_time)
             gl.glDrawArrays(gl.GL_TRIANGLE_STRIP, 0, 4)
 
     def on_key_press(self, symbol, modifiers):


### PR DESCRIPTION
The script fractal3d.py fails with Python 3.8, because time.clock() was removed from the Python API. (https://docs.python.org/3/whatsnew/3.8.html#api-and-feature-removals)

In this PR i replaced `time.clock()` with `time.process_time()`